### PR TITLE
New editor to bump a rug archive version

### DIFF
--- a/.atomist/editors/BumpVersion.ts
+++ b/.atomist/editors/BumpVersion.ts
@@ -1,25 +1,40 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Project } from "@atomist/rug/model/Project";
 import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
-import { Pattern } from "@atomist/rug/operations/RugOperation";
 
 /**
- * Increment the version in manifest.yml
+ * Increment the Rug archive version in manifest.yml
  */
-@Editor("BumpVersion", "bump the version of this rug archive")
+@Editor("BumpVersion", "bump the version of this Rug archive project")
 @Tags("rug", "version")
 export class BumpVersion implements EditProject {
 
     @Parameter({
         displayName: "version component",
         description: "how bumped is it? major/minor/patch",
-        pattern: Pattern.any,
-        validInput: "major | minor | patch",
-        minLength: 1,
+        pattern: "^(major|minor|patch)$",
+        validInput: "one of: major, minor, patch",
+        minLength: 5,
         maxLength: 5,
         required: false,
     })
-    public component: string = "patch";
+    public component: string = "minor";
 
     public edit(project: Project) {
         const versionRegex = /version: "?(\d+)\.(\d+)\.(\d+)"?/;
@@ -31,13 +46,13 @@ export class BumpVersion implements EditProject {
         const versionMatch = versionRegex.exec(manifest.content);
         if (!versionMatch) {
             throw new Error(
-               // tslint:disable-next-line:max-line-length
-               `Unable to parse current version. I can only increment a nice simple 1.2.3 format. But I see: ${manifest.content}`);
+                // tslint:disable-next-line:max-line-length
+                `Unable to parse current version. I can only increment a nice simple 1.2.3 format. But I see: ${manifest.content}`);
         }
 
-        let major = parseInt(versionMatch[1]);
-        let minor = parseInt(versionMatch[2]);
-        let patch = parseInt(versionMatch[3]);
+        let major = parseInt(versionMatch[1], 10);
+        let minor = parseInt(versionMatch[2], 10);
+        let patch = parseInt(versionMatch[3], 10);
         if (this.component === "major") {
             major = major + 1;
             minor = 0;
@@ -51,8 +66,7 @@ export class BumpVersion implements EditProject {
             throw new Error(`Unknown version component '${this.component}'. Should be major|minor|patch`);
         }
 
-        const newContent = manifest.content.replace(versionRegex, `version: "${major}.${minor}.${patch}"`);
-        manifest.setContent(newContent);
+        manifest.regexpReplace("version:.*", `version: "${major}.${minor}.${patch}"`);
     }
 }
 

--- a/.atomist/editors/BumpVersion.ts
+++ b/.atomist/editors/BumpVersion.ts
@@ -1,7 +1,7 @@
-import { EditProject } from '@atomist/rug/operations/ProjectEditor';
-import { Project } from '@atomist/rug/model/Project';
-import { Pattern } from '@atomist/rug/operations/RugOperation';
-import { Editor, Parameter, Tags } from '@atomist/rug/operations/Decorators';
+import { Project } from "@atomist/rug/model/Project";
+import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
+import { EditProject } from "@atomist/rug/operations/ProjectEditor";
+import { Pattern } from "@atomist/rug/operations/RugOperation";
 
 /**
  * Increment the version in manifest.yml
@@ -17,39 +17,41 @@ export class BumpVersion implements EditProject {
         validInput: "major | minor | patch",
         minLength: 1,
         maxLength: 5,
-        required: false
+        required: false,
     })
-    component: string = "patch";
+    public component: string = "patch";
 
-    edit(project: Project) {
-        let versionRegex = /version: "?(\d+)\.(\d+)\.(\d+)"?/;
-        let manifest = project.findFile(".atomist/manifest.yml");
+    public edit(project: Project) {
+        const versionRegex = /version: "?(\d+)\.(\d+)\.(\d+)"?/;
+        const manifest = project.findFile(".atomist/manifest.yml");
         if (manifest == null) {
             // not a rug archive
             return;
         }
-        let versionMatch = versionRegex.exec(manifest.content);
+        const versionMatch = versionRegex.exec(manifest.content);
         if (!versionMatch) {
-            throw "Unable to parse current version. I can only increment a nice simple 1.2.3 format. But I see: " + manifest.content
+            throw new Error(
+               // tslint:disable-next-line:max-line-length
+               `Unable to parse current version. I can only increment a nice simple 1.2.3 format. But I see: ${manifest.content}`);
         }
 
         let major = parseInt(versionMatch[1]);
         let minor = parseInt(versionMatch[2]);
         let patch = parseInt(versionMatch[3]);
-        if (this.component == "major") {
+        if (this.component === "major") {
             major = major + 1;
             minor = 0;
             patch = 0;
-        } else if (this.component == "minor") {
+        } else if (this.component === "minor") {
             minor = minor + 1;
             patch = 0;
-        } else if (this.component == "patch") {
+        } else if (this.component === "patch") {
             patch = patch + 1;
         } else {
-            throw `Unknown version component '${this.component}'. Should be major|minor|patch`;
+            throw new Error(`Unknown version component '${this.component}'. Should be major|minor|patch`);
         }
 
-        let newContent = manifest.content.replace(versionRegex, `version: "${major}.${minor}.${patch}"`)
+        const newContent = manifest.content.replace(versionRegex, `version: "${major}.${minor}.${patch}"`);
         manifest.setContent(newContent);
     }
 }

--- a/.atomist/editors/BumpVersion.ts
+++ b/.atomist/editors/BumpVersion.ts
@@ -1,0 +1,57 @@
+import { EditProject } from '@atomist/rug/operations/ProjectEditor';
+import { Project } from '@atomist/rug/model/Project';
+import { Pattern } from '@atomist/rug/operations/RugOperation';
+import { Editor, Parameter, Tags } from '@atomist/rug/operations/Decorators';
+
+/**
+ * Increment the version in manifest.yml
+ */
+@Editor("BumpVersion", "bump the version of this rug archive")
+@Tags("rug", "version")
+export class BumpVersion implements EditProject {
+
+    @Parameter({
+        displayName: "version component",
+        description: "how bumped is it? major/minor/patch",
+        pattern: Pattern.any,
+        validInput: "major | minor | patch",
+        minLength: 1,
+        maxLength: 5,
+        required: false
+    })
+    component: string = "patch";
+
+    edit(project: Project) {
+        let versionRegex = /version: "?(\d+)\.(\d+)\.(\d+)"?/;
+        let manifest = project.findFile(".atomist/manifest.yml");
+        if (manifest == null) {
+            // not a rug archive
+            return;
+        }
+        let versionMatch = versionRegex.exec(manifest.content);
+        if (!versionMatch) {
+            throw "Unable to parse current version. I can only increment a nice simple 1.2.3 format. But I see: " + manifest.content
+        }
+
+        let major = parseInt(versionMatch[1]);
+        let minor = parseInt(versionMatch[2]);
+        let patch = parseInt(versionMatch[3]);
+        if (this.component == "major") {
+            major = major + 1;
+            minor = 0;
+            patch = 0;
+        } else if (this.component == "minor") {
+            minor = minor + 1;
+            patch = 0;
+        } else if (this.component == "patch") {
+            patch = patch + 1;
+        } else {
+            throw `Unknown version component '${this.component}'. Should be major|minor|patch`;
+        }
+
+        let newContent = manifest.content.replace(versionRegex, `version: "${major}.${minor}.${patch}"`)
+        manifest.setContent(newContent);
+    }
+}
+
+export const bumpVersion = new BumpVersion();

--- a/.atomist/manifest.yml
+++ b/.atomist/manifest.yml
@@ -1,7 +1,7 @@
 group: atomist
 artifact: rug-rugs
 version: "0.30.0"
-requires: "[1.0.0-m.2,2.0.0)"
+requires: "[1.0.0-m.3,2.0.0)"
 dependencies:
 extensions:
 - "com.atomist.rug:rug-function-http:[0.7.3,1.0.0)"

--- a/.atomist/package.json
+++ b/.atomist/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@atomist/rugs": "^1.0.0-m.3"
+    "@atomist/rugs": "^1.0.0-m.4"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",

--- a/.atomist/tests/project/AddTypeScriptEventHandlerSteps.ts
+++ b/.atomist/tests/project/AddTypeScriptEventHandlerSteps.ts
@@ -21,7 +21,7 @@ Given("a manifest file", (p) => {
     p.addFile(".atomist/manifest.yml", `group: test-rugs
 artifact: test-manifest
 version: "0.1.0"
-requires: "[0.18.2,1.0.0)"
+requires: "[0.18.2,0.99.99)"
 dependencies:
 extensions:
 `);

--- a/.atomist/tests/project/BumpVersionSteps.ts
+++ b/.atomist/tests/project/BumpVersionSteps.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project } from "@atomist/rug/model/Project";
+import { Given, ProjectScenarioWorld, Then, When } from "@atomist/rug/test/project/Core";
+
+Given("a bad manifest file", (p: Project, w: ProjectScenarioWorld) => {
+    p.addFile(".atomist/manifest.yml", `group: test-rugs
+artifact: test-manifest
+version: "1.0"
+requires: "[1.0.0-m.3,2.0.0)"
+`);
+});
+
+When("BumpVersion bumps the (major|minor|patch) version", (p: Project, w: ProjectScenarioWorld, component: string) => {
+    const editor = w.editor("BumpVersion");
+    w.editWith(editor, { component });
+});

--- a/.atomist/tests/project/BumpVersionTest.feature
+++ b/.atomist/tests/project/BumpVersionTest.feature
@@ -1,0 +1,48 @@
+# Copyright © 2017 Atomist, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+Feature: Automatically increment Rug archive version
+  Use an editor to safely and easily increment the
+  version of a Rug archive in the manifest file.
+
+
+  Scenario: BumpVersion should increment the major version
+    Given a manifest file
+    When BumpVersion bumps the major version
+    Then parameters were valid
+    Then changes were made
+    Then file at .atomist/manifest.yml should contain version: "1.0.0"
+
+
+  Scenario: BumpVersion should increment the minor version
+    Given a manifest file
+    When BumpVersion bumps the minor version
+    Then parameters were valid
+    Then changes were made
+    Then file at .atomist/manifest.yml should contain version: "0.2.0"
+
+
+  Scenario: BumpVersion should increment the patch level
+    Given a manifest file
+    When BumpVersion bumps the patch version
+    Then parameters were valid
+    Then changes were made
+    Then file at .atomist/manifest.yml should contain version: "0.1.1"
+
+
+  Scenario: AddManifestYml should refuse to change bad version
+    Given a bad manifest file
+    When BumpVersion bumps the major version
+    Then the scenario aborted

--- a/.atomist/tslint.json
+++ b/.atomist/tslint.json
@@ -11,7 +11,8 @@
         ],
         "max-classes-per-file": false,
         "object-literal-sort-keys": false,
-        "no-console": false
+        "no-console": false,
+        "radix": false
     },
     "rulesDirectory": []
 }

--- a/.atomist/tslint.json
+++ b/.atomist/tslint.json
@@ -11,8 +11,7 @@
         ],
         "max-classes-per-file": false,
         "object-literal-sort-keys": false,
-        "no-console": false,
-        "radix": false
+        "no-console": false
     },
     "rulesDirectory": []
 }

--- a/.atomist/yarn.lock
+++ b/.atomist/yarn.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@atomist/cortex@1.0.0-m.2":
-  version "1.0.0-m.2"
-  resolved "https://registry.yarnpkg.com/@atomist/cortex/-/cortex-1.0.0-m.2.tgz#b9432c3e72f198227af02fc11448798cb4a1a372"
-  dependencies:
-    "@atomist/rug" "1.0.0-m.2"
-
-"@atomist/rug@1.0.0-m.2":
-  version "1.0.0-m.2"
-  resolved "https://registry.yarnpkg.com/@atomist/rug/-/rug-1.0.0-m.2.tgz#06d14cfe09d66023b6f69aad381fe8ece96b6faa"
-
-"@atomist/rugs@^1.0.0-m.3":
+"@atomist/cortex@1.0.0-m.3":
   version "1.0.0-m.3"
-  resolved "https://registry.yarnpkg.com/@atomist/rugs/-/rugs-1.0.0-m.3.tgz#f229584bd2e3558748ebc8023b7312ebb3dcd1a5"
+  resolved "https://registry.yarnpkg.com/@atomist/cortex/-/cortex-1.0.0-m.3.tgz#88c32585ec819541932246d24c02ba6b70878512"
   dependencies:
-    "@atomist/cortex" "1.0.0-m.2"
-    "@atomist/rug" "1.0.0-m.2"
+    "@atomist/rug" "1.0.0-m.3"
+
+"@atomist/rug@1.0.0-m.3":
+  version "1.0.0-m.3"
+  resolved "https://registry.yarnpkg.com/@atomist/rug/-/rug-1.0.0-m.3.tgz#5768338bd1e20a6138b1ed0db38e3c881206c867"
+
+"@atomist/rugs@^1.0.0-m.4":
+  version "1.0.0-m.4"
+  resolved "https://registry.yarnpkg.com/@atomist/rugs/-/rugs-1.0.0-m.4.tgz#ee26ac9d8aa3a45b1d7fff176999e716f9704cb8"
+  dependencies:
+    "@atomist/cortex" "1.0.0-m.3"
+    "@atomist/rug" "1.0.0-m.3"
     mustache "^2.3.0"
 
 "@types/empower@*":
@@ -50,6 +50,10 @@ acorn-es7-plugin@^1.0.10, acorn-es7-plugin@^1.0.12:
 acorn@^4.0.0:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
+
+acorn@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -164,7 +168,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-brace-expansion@^1.0.0:
+brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
@@ -399,8 +403,8 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
     once "^1.4.0"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.15"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
+  version "0.10.16"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.16.tgz#1ef1b04f3d09db6a5d630226d62202f2e425e45a"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
@@ -491,10 +495,10 @@ espower-location-detector@^1.0.0:
     xtend "^4.0.0"
 
 espower-source@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/espower-source/-/espower-source-2.1.0.tgz#d2ac47d23c93c4fbc4bf9f9d929cea103b90433e"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/espower-source/-/espower-source-2.2.0.tgz#7e005255ae47b5c136448644b3f3d802d503f752"
   dependencies:
-    acorn "^4.0.0"
+    acorn "^5.0.0"
     acorn-es7-plugin "^1.0.10"
     convert-source-map "^1.1.1"
     empower-assert "^1.0.0"
@@ -629,7 +633,7 @@ fstream@^1.0.0, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-gauge@~2.7.1:
+gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
   dependencies:
@@ -957,10 +961,10 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
 "minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
-    brace-expansion "^1.0.0"
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -1045,12 +1049,12 @@ node-gyp@^3.2.1:
     abbrev "1"
 
 "npmlog@0 || 1 || 2 || 3 || 4":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
-    gauge "~2.7.1"
+    gauge "~2.7.3"
     set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
@@ -1508,9 +1512,13 @@ traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
 
+tslib@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.0.tgz#6e8366695f72961252b35167b0dd4fbeeafba491"
+
 tslint@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.1.0.tgz#51a47baeeb58956fcd617bd2cf00e2ef0eea2ed9"
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.2.0.tgz#16a2addf20cb748385f544e9a0edab086bc34114"
   dependencies:
     babel-code-frame "^6.22.0"
     colors "^1.1.2"
@@ -1520,9 +1528,10 @@ tslint@^5.0.0:
     optimist "~0.6.0"
     resolve "^1.3.2"
     semver "^5.3.0"
-    tsutils "^1.4.0"
+    tslib "^1.6.0"
+    tsutils "^1.8.0"
 
-tsutils@^1.4.0:
+tsutils@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.8.0.tgz#bf8118ed8e80cd5c9fc7d75728c7963d44ed2f52"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -   Command handler `show latest versions` that displays the latest versions
     of `com.atomist:rug` and `@atomist/rugs`
+-   BumpVersion editor
 
 ## [0.29.0] - 2017-04-26
 


### PR DESCRIPTION
This addresses issue #49 

I use this in my `republish` cli gesture; as part of publishing it's useful to bump the version. So this is handy in scripts.