### PR TITLE
Accurate name for CommandHandler.handle's parameter

### DIFF
--- a/.atomist/editors/AddTypeScriptCommandHandler.ts
+++ b/.atomist/editors/AddTypeScriptCommandHandler.ts
@@ -71,7 +71,7 @@ export class AddTypeScriptCommandHandler implements EditProject {
         project.copyEditorBackingFileOrFailToDestination(srcTestPath, testPath);
         project.copyEditorBackingFileOrFailToDestination(srcFeaturePath, featurePath);
 
-        const srcDescription = "sample TypeScript command handler used by AddTypeScriptCommandHandler";
+        const srcDescription = "A sample TypeScript command handler used by AddTypeScriptCommandHandler";
         const srcIntent = `run ${srcHandlerName}`;
         const srcHandlerConstName = "typeScriptCommandHandler";
         const handlerConstName = this.handlerName.charAt(0).toLowerCase() + this.handlerName.slice(1);

--- a/.atomist/editors/AddTypeScriptEventHandler.ts
+++ b/.atomist/editors/AddTypeScriptEventHandler.ts
@@ -72,7 +72,7 @@ export class AddTypeScriptEventHandler implements EditProject {
         project.copyEditorBackingFileOrFailToDestination(srcTestPath, testPath);
         project.copyEditorBackingFileOrFailToDestination(srcFeaturePath, featurePath);
 
-        const srcDescription = "sample TypeScript event handler used by AddTypeScriptEventHandler";
+        const srcDescription = "A sample TypeScript event handler used by AddTypeScriptEventHandler";
         const srcPathExpression = "/Tag()";
         const srcHandlerConstName = "typeScriptEventHandler";
         const handlerConstName = this.handlerName.charAt(0).toLowerCase() + this.handlerName.slice(1);

--- a/.atomist/handlers/command/TypeScriptCommandHandler.ts
+++ b/.atomist/handlers/command/TypeScriptCommandHandler.ts
@@ -5,7 +5,7 @@ import { Pattern } from "@atomist/rug/operations/RugOperation";
 /**
  * A sample TypeScript command handler used by AddTypeScriptCommandHandler.
  */
-@CommandHandler("TypeScriptCommandHandler", "sample TypeScript command handler used by AddTypeScriptCommandHandler")
+@CommandHandler("TypeScriptCommandHandler", "A sample TypeScript command handler used by AddTypeScriptCommandHandler")
 @Tags("documentation")
 @Intent("run TypeScriptCommandHandler")
 export class TypeScriptCommandHandler implements HandleCommand {

--- a/.atomist/handlers/command/TypeScriptCommandHandler.ts
+++ b/.atomist/handlers/command/TypeScriptCommandHandler.ts
@@ -21,7 +21,7 @@ export class TypeScriptCommandHandler implements HandleCommand {
     })
     public inputParameter: string = "default value";
 
-    public handle(command: HandlerContext): CommandPlan {
+    public handle(context: HandlerContext): CommandPlan {
         const message = new ResponseMessage(`Successfully ran TypeScriptCommandHandler: ${this.inputParameter}`);
         return CommandPlan.ofMessage(message);
     }

--- a/.atomist/handlers/event/TypeScriptEventHandler.ts
+++ b/.atomist/handlers/event/TypeScriptEventHandler.ts
@@ -7,7 +7,7 @@ import { Tag } from "@atomist/cortex/Tag";
 /**
  * A sample TypeScript event handler used by AddTypeScriptEventHandler.
  */
-@EventHandler("TypeScriptEventHandler", "sample TypeScript event handler used by AddTypeScriptEventHandler", "/Tag()")
+@EventHandler("TypeScriptEventHandler", "A sample TypeScript event handler used by AddTypeScriptEventHandler", "/Tag()")
 @Tags("documentation")
 export class TypeScriptEventHandler implements HandleEvent<Tag, Tag> {
     public handle(event: Match<Tag, Tag>): EventPlan {


### PR DESCRIPTION
@kipz says this name is more accurate

while I was here, I made the descriptions correspond in the command handler and event handlers too. (It was leaving the "A " in front of the substituted description in the comment, before)