### PR TITLE
Add UpdateRug, renamed predicates

### DIFF
--- a/.atomist/editors/AddManifestYml.ts
+++ b/.atomist/editors/AddManifestYml.ts
@@ -20,7 +20,7 @@ import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 import { Pattern } from "@atomist/rug/operations/RugOperation";
 
-import { IsRugArchive } from "./RugEditorsPredicates";
+import { isRugArchive } from "./RugEditorsPredicates";
 import { RugParameters } from "./RugParameters";
 
 @Editor("AddManifestYml", "adds a Rug archive manifest")
@@ -52,7 +52,8 @@ export class AddManifestYml implements EditProject {
     public version: string = "0.1.0";
 
     public edit(project: Project) {
-        if (IsRugArchive(project)) {
+        if (isRugArchive(project)) {
+            console.log("project already appears to be a Rug archive project");
             return;
         }
 

--- a/.atomist/editors/AddTypeScript.ts
+++ b/.atomist/editors/AddTypeScript.ts
@@ -19,20 +19,18 @@ import { Editor, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 import { Pattern } from "@atomist/rug/operations/RugOperation";
 
-import { IsRugArchive, IsSetUpForTypeScript } from "./RugEditorsPredicates";
+import { isRugArchive, isSetUpForTypeScript, NotRugArchiveError } from "./RugEditorsPredicates";
 
 @Editor("AddTypeScript", "adds TypeScript supporting files to a Rug archive project")
 @Tags("rug", "atomist", "typescript")
 export class AddTypeScript implements EditProject {
 
     public edit(project: Project) {
-        if (!IsRugArchive(project)) {
-            const err = "project does not appear to be a Rug project";
-            console.log(err);
-            throw new Error(err);
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
         }
 
-        if (IsSetUpForTypeScript(project)) {
+        if (isSetUpForTypeScript(project)) {
             return;
         }
 

--- a/.atomist/editors/AddTypeScriptCommandHandler.ts
+++ b/.atomist/editors/AddTypeScriptCommandHandler.ts
@@ -19,24 +19,24 @@ import { Project } from "@atomist/rug/model/Project";
 import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 
-import { IsRugArchive } from "./RugEditorsPredicates";
+import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
 import { RugParameters } from "./RugParameters";
 
-@Editor("AddTypeScriptCommandHandler", "adds a TypeScript Rug event handler to a Rug project")
+@Editor("AddTypeScriptCommandHandler", "adds a TypeScript Rug command handler to a Rug project")
 @Tags("rug", "atomist", "typescript")
 export class AddTypeScriptCommandHandler implements EditProject {
 
     @Parameter({
         ...RugParameters.Name,
-        displayName: "Event Handler Name",
-        description: "name of new event handler to add to Rug project",
+        displayName: "Command Handler Name",
+        description: "name of new command handler to add to Rug project",
     })
     public handlerName: string;
 
     @Parameter({
         ...RugParameters.Description,
         displayName: "Handler Description",
-        description: "short description of event handler to add to Rug project",
+        description: "short description of command handler to add to Rug project",
     })
     public description: string;
 
@@ -51,10 +51,8 @@ export class AddTypeScriptCommandHandler implements EditProject {
     public intent: string;
 
     public edit(project: Project) {
-        if (!IsRugArchive(project)) {
-            const err = "project does not appear to be a Rug project";
-            console.log(err);
-            throw new Error(err);
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
         }
 
         project.editWith("AddTypeScript", {});
@@ -71,7 +69,7 @@ export class AddTypeScriptCommandHandler implements EditProject {
         project.copyEditorBackingFileOrFailToDestination(srcTestPath, testPath);
         project.copyEditorBackingFileOrFailToDestination(srcFeaturePath, featurePath);
 
-        const srcDescription = "A sample TypeScript command handler used by AddTypeScriptCommandHandler";
+        const srcDescription = "sample TypeScript command handler used by AddTypeScriptCommandHandler";
         const srcIntent = `run ${srcHandlerName}`;
         const srcHandlerConstName = "typeScriptCommandHandler";
         const handlerConstName = this.handlerName.charAt(0).toLowerCase() + this.handlerName.slice(1);

--- a/.atomist/editors/AddTypeScriptEditor.ts
+++ b/.atomist/editors/AddTypeScriptEditor.ts
@@ -20,7 +20,7 @@ import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 
 import { addInstructionsToReadMe, readMeInstructions } from "./AddFunctions";
-import { IsRugArchive, IsSetUpForTypeScript } from "./RugEditorsPredicates";
+import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
 import { RugParameters } from "./RugParameters";
 
 @Editor("AddTypeScriptEditor", "adds a TypeScript Rug editor to a Rug project")
@@ -43,10 +43,8 @@ export class AddTypeScriptEditor implements EditProject {
 
     public edit(project: Project) {
 
-        if (!IsRugArchive(project)) {
-            const err = "project does not appear to be a Rug project";
-            console.log(err);
-            throw new Error(err);
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
         }
 
         project.editWith("AddTypeScript", {});

--- a/.atomist/editors/AddTypeScriptEventHandler.ts
+++ b/.atomist/editors/AddTypeScriptEventHandler.ts
@@ -19,7 +19,7 @@ import { Project } from "@atomist/rug/model/Project";
 import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 
-import { IsRugArchive } from "./RugEditorsPredicates";
+import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
 import { RugParameters } from "./RugParameters";
 
 @Editor("AddTypeScriptEventHandler", "adds a TypeScript Rug event handler to a Rug project")
@@ -52,10 +52,8 @@ export class AddTypeScriptEventHandler implements EditProject {
     public pathExpression: string = "/Tag()";
 
     public edit(project: Project) {
-        if (!IsRugArchive(project)) {
-            const err = "project does not appear to be a Rug project";
-            console.log(err);
-            throw new Error(err);
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
         }
 
         project.editWith("AddTypeScript", {});
@@ -72,7 +70,7 @@ export class AddTypeScriptEventHandler implements EditProject {
         project.copyEditorBackingFileOrFailToDestination(srcTestPath, testPath);
         project.copyEditorBackingFileOrFailToDestination(srcFeaturePath, featurePath);
 
-        const srcDescription = "A sample TypeScript event handler used by AddTypeScriptEventHandler";
+        const srcDescription = "sample TypeScript event handler used by AddTypeScriptEventHandler";
         const srcPathExpression = "/Tag()";
         const srcHandlerConstName = "typeScriptEventHandler";
         const handlerConstName = this.handlerName.charAt(0).toLowerCase() + this.handlerName.slice(1);

--- a/.atomist/editors/AddTypeScriptGenerator.ts
+++ b/.atomist/editors/AddTypeScriptGenerator.ts
@@ -20,7 +20,7 @@ import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 
 import { addInstructionsToReadMe, readMeInstructions } from "./AddFunctions";
-import { IsRugArchive } from "./RugEditorsPredicates";
+import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
 import { RugParameters } from "./RugParameters";
 
 @Editor("AddTypeScriptGenerator", "adds a TypeScript generator to a Rug project")
@@ -42,10 +42,8 @@ export class AddTypeScriptGenerator implements EditProject {
     public description: string;
 
     public edit(project: Project) {
-        if (!IsRugArchive(project)) {
-            const err = "project does not appear to be a Rug project";
-            console.log(err);
-            throw new Error(err);
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
         }
 
         project.editWith("AddTypeScript", {});

--- a/.atomist/editors/RugEditorsPredicates.ts
+++ b/.atomist/editors/RugEditorsPredicates.ts
@@ -16,10 +16,32 @@
 
 import { Project } from "@atomist/rug/model/Project";
 
-export function IsRugArchive(p: Project): boolean {
+import deprecated from "deprecated-decorator";
+
+export function isRugArchive(p: Project): boolean {
     return p.fileExists(".atomist/manifest.yml");
 }
 
-export function IsSetUpForTypeScript(p: Project): boolean {
+export function isSetUpForTypeScript(p: Project): boolean {
     return p.fileExists(".atomist/package.json");
 }
+
+export class NotRugArchiveError extends Error {
+    constructor() {
+        super("project does not appear to be a Rug project");
+    }
+}
+
+export const IsRugArchive = deprecated({
+    alternative: "isRugArchive",
+    version: "0.30.0",
+}, function IsRugArchive(p: Project): boolean {
+    return isRugArchive(p);
+});
+
+export const IsSetUpForTypeScript = deprecated({
+    alternative: "isSetUpForTypeScript",
+    version: "0.30.0",
+}, function IsSetUpForTypeScript(p: Project): boolean {
+    return isSetUpForTypeScript(p);
+});

--- a/.atomist/editors/UpdateRug.ts
+++ b/.atomist/editors/UpdateRug.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project } from "@atomist/rug/model/Project";
+import { Editor, Tags } from "@atomist/rug/operations/Decorators";
+import { EditProject } from "@atomist/rug/operations/ProjectEditor";
+import { Pattern } from "@atomist/rug/operations/RugOperation";
+
+import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
+import { updateRugFiles } from "./UpdateSupportFiles";
+
+@Editor("UpdateRug", "updates Rug dependencies and support files")
+@Tags("rug", "atomist")
+export class UpdateRug implements EditProject {
+
+    public edit(project: Project) {
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
+        }
+
+        updateRugFiles(project);
+
+        const manifestPath = ".atomist/manifest.yml";
+        const manifest = project.findFile(manifestPath);
+        if (manifest === null || manifest === undefined) {
+            const err = "failed to load manifest";
+            throw new Error(err);
+        }
+        const archiveManifest = manifestPath + "-archive.tmp";
+        project.copyEditorBackingFileOrFailToDestination(manifestPath, archiveManifest);
+        const archiveManifestContents = project.findFile(archiveManifest).content;
+        project.deleteFile(archiveManifest);
+        const versionRegex = /^requires\s*:\s*(.*)\s*$/m;
+        const archiveRugVersionMatch = versionRegex.exec(archiveManifestContents);
+        if (archiveRugVersionMatch === null || archiveRugVersionMatch.length < 2) {
+            throw new Error(`failed to match version in archive manifest: ${archiveManifestContents}`);
+        }
+        manifest.regexpReplace("(?m)^requires\\s*:.*", `requires: ${archiveRugVersionMatch[1]}`);
+
+        const pkgJsonPath = ".atomist/package.json";
+        const pkgJson = project.findFile(pkgJsonPath);
+        if (pkgJson === null || pkgJson === undefined) {
+            throw new Error("failed to load package.json");
+        }
+        const archivePkgJson = pkgJsonPath + "-archive.tmp";
+        project.copyEditorBackingFileOrFailToDestination(pkgJsonPath, archivePkgJson);
+        const pkgJsonObj = JSON.parse(project.findFile(archivePkgJson).content);
+        project.deleteFile(archivePkgJson);
+        const rugsName = "@atomist/rugs";
+        const rugsVersion: string = pkgJsonObj.dependencies[rugsName];
+        pkgJson.regexpReplace(`"@atomist/rugs"\\s*:\\s*"[^"]+"(,?)`, `"@atomist/rugs": "${rugsVersion}"$1`);
+    }
+}
+
+export const updateRug = new UpdateRug();

--- a/.atomist/editors/UpdateSupportFiles.ts
+++ b/.atomist/editors/UpdateSupportFiles.ts
@@ -19,45 +19,47 @@ import { Editor, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 import { Pattern } from "@atomist/rug/operations/RugOperation";
 
-import { IsRugArchive } from "./RugEditorsPredicates";
+import { isRugArchive, NotRugArchiveError } from "./RugEditorsPredicates";
 
 @Editor("UpdateSupportFiles", "updates Rug project TypeScript and build files")
 @Tags("rug", "atomist", "typescript")
 export class UpdateSupportFiles implements EditProject {
 
     public edit(project: Project) {
-        if (!IsRugArchive(project)) {
-            const err = "project does not appear to be a Rug project";
-            console.log(err);
-            throw new Error(err);
+        if (!isRugArchive(project)) {
+            throw new NotRugArchiveError();
         }
 
-        const oldFiles = [
-            ".atomist/build/cli-build.yml",
-            ".atomist/build/cli-dev.yml",
-            ".atomist/build/cli-release.yml",
-        ];
-        for (const f of oldFiles) {
-            project.deleteFile(f);
-        }
-
-        const supportFiles = [
-            ".atomist/tsconfig.json",
-            ".atomist/tslint.json",
-            ".atomist/.gitignore",
-            ".atomist/build/cli.yml",
-            ".atomist/build/travis-build.bash",
-        ];
-        for (const f of supportFiles) {
-            project.deleteFile(f);
-            project.copyEditorBackingFileOrFail(f);
-        }
-
-        const pkgJsonPath = ".atomist/package.json";
-        if (!project.fileExists(pkgJsonPath)) {
-            project.copyEditorBackingFileOrFail(pkgJsonPath);
-        }
+        updateRugFiles(project);
     }
 }
 
 export const updateSupportFiles = new UpdateSupportFiles();
+
+export function updateRugFiles(project: Project) {
+    const oldFiles = [
+        ".atomist/build/cli-build.yml",
+        ".atomist/build/cli-dev.yml",
+        ".atomist/build/cli-release.yml",
+    ];
+    for (const f of oldFiles) {
+        project.deleteFile(f);
+    }
+
+    const supportFiles = [
+        ".atomist/tsconfig.json",
+        ".atomist/tslint.json",
+        ".atomist/.gitignore",
+        ".atomist/build/cli.yml",
+        ".atomist/build/travis-build.bash",
+    ];
+    for (const f of supportFiles) {
+        project.deleteFile(f);
+        project.copyEditorBackingFileOrFail(f);
+    }
+
+    const pkgJsonPath = ".atomist/package.json";
+    if (!project.fileExists(pkgJsonPath)) {
+        project.copyEditorBackingFileOrFail(pkgJsonPath);
+    }
+}

--- a/.atomist/handlers/command/TypeScriptCommandHandler.ts
+++ b/.atomist/handlers/command/TypeScriptCommandHandler.ts
@@ -5,7 +5,7 @@ import { Pattern } from "@atomist/rug/operations/RugOperation";
 /**
  * A sample TypeScript command handler used by AddTypeScriptCommandHandler.
  */
-@CommandHandler("TypeScriptCommandHandler", "A sample TypeScript command handler used by AddTypeScriptCommandHandler")
+@CommandHandler("TypeScriptCommandHandler", "sample TypeScript command handler used by AddTypeScriptCommandHandler")
 @Tags("documentation")
 @Intent("run TypeScriptCommandHandler")
 export class TypeScriptCommandHandler implements HandleCommand {

--- a/.atomist/handlers/event/TypeScriptEventHandler.ts
+++ b/.atomist/handlers/event/TypeScriptEventHandler.ts
@@ -7,7 +7,7 @@ import { Tag } from "@atomist/cortex/Tag";
 /**
  * A sample TypeScript event handler used by AddTypeScriptEventHandler.
  */
-@EventHandler("TypeScriptEventHandler", "A sample TypeScript event handler used by AddTypeScriptEventHandler", "/Tag()")
+@EventHandler("TypeScriptEventHandler", "sample TypeScript event handler used by AddTypeScriptEventHandler", "/Tag()")
 @Tags("documentation")
 export class TypeScriptEventHandler implements HandleEvent<Tag, Tag> {
     public handle(event: Match<Tag, Tag>): EventPlan {

--- a/.atomist/package.json
+++ b/.atomist/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "@atomist/rugs": "^1.0.0-m.4"
+    "@atomist/rugs": "^1.0.0-m.4",
+    "deprecated-decorator": "0.1.6"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",

--- a/.atomist/tests/project/AddTypeScriptCommandHandlerTest.feature
+++ b/.atomist/tests/project/AddTypeScriptCommandHandlerTest.feature
@@ -20,7 +20,7 @@ Feature: AddTypeScriptCommandHandler should add a sample command handler
 
 
   Scenario: AddTypeScriptCommandHandler should add a command handler
-    Given a manifest file
+    Given a Rug archive manifest
     Given an NPM package file
     When AddTypeScriptCommandHandler is run
     Then parameters were valid

--- a/.atomist/tests/project/AddTypeScriptEventHandlerSteps.ts
+++ b/.atomist/tests/project/AddTypeScriptEventHandlerSteps.ts
@@ -17,32 +17,41 @@
 import { Project } from "@atomist/rug/model/Project";
 import { Given, ProjectScenarioWorld, Then, When } from "@atomist/rug/test/project/Core";
 
-Given("a manifest file", (p) => {
-    p.addFile(".atomist/manifest.yml", `group: test-rugs
-artifact: test-manifest
-version: "0.1.0"
-requires: "[0.18.2,0.99.99)"
-dependencies:
-extensions:
-`);
-});
-
-Given("an NPM package file", (p) => {
+Given("an NPM package file", (p: Project) => {
     p.addFile(".atomist/package.json", `{
   "dependencies": {
-    "@atomist/rug": "0.18.2"
+    "@atomist/rugs": "0.18.2",
+    "mustache": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.40",
+    "@types/mustache": "^0.8.29",
+    "@types/power-assert": "^1.4.29",
+    "espower-typescript": "^8.0.0",
+    "mocha": "^3.2.0",
+    "power-assert": "^1.4.2",
+    "tslint": "^5.0.0",
+    "typescript": "2.3.2",
+    "yarn": "^0.23.4"
+  },
+  "directories": {
+    "test": "mocha"
+  },
+  "scripts": {
+    "lint": "tslint '**/*.ts' --exclude 'node_modules/**' -t verbose",
+    "mocha": "mocha --compilers ts:espower-typescript/guess 'mocha/**/*.ts'",
+    "test": "yarn run mocha && rug test"
   }
 }
 `);
 });
 
 const handlerName = "MyNewHandler";
-const description = "This handler rocks";
+const description = "this handler rocks";
 
-When("AddTypeScriptEventHandler is run with default path expression", (p, world) => {
-    const psworld = world as ProjectScenarioWorld;
-    const editor = psworld.editor("AddTypeScriptEventHandler");
-    psworld.editWith(editor, { handlerName, description });
+When("AddTypeScriptEventHandler is run with default path expression", (p: Project, w: ProjectScenarioWorld) => {
+    const editor = w.editor("AddTypeScriptEventHandler");
+    w.editWith(editor, { handlerName, description });
 });
 
 const pathExpression = `/Push()[/on::Repo()/channel::ChatChannel()]
@@ -50,10 +59,9 @@ const pathExpression = `/Push()[/on::Repo()/channel::ChatChannel()]
                                 [/hasGithubIdentity::Person()/hasChatIdentity::ChatId()]?]`;
 const newRootNode = "Push";
 
-When("AddTypeScriptEventHandler is run providing a path expression", (p, world) => {
-    const psworld = world as ProjectScenarioWorld;
-    const editor = psworld.editor("AddTypeScriptEventHandler");
-    psworld.editWith(editor, {
+When("AddTypeScriptEventHandler is run providing a path expression", (p: Project, w: ProjectScenarioWorld) => {
+    const editor = w.editor("AddTypeScriptEventHandler");
+    w.editWith(editor, {
         handlerName,
         description,
         pathExpression,
@@ -62,102 +70,108 @@ When("AddTypeScriptEventHandler is run providing a path expression", (p, world) 
 
 const handlerPath = ".atomist/handlers/event/MyNewHandler.ts";
 
-Then("the event handler file exists", (p, world) => {
+Then("the event handler file exists", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileExists(handlerPath);
 });
 
-Then("the event handler file contains the name", (p, world) => {
+Then("the event handler file contains the name", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, `class ${handlerName}`);
 });
 
-Then("the event handler file contains the description", (p, world) => {
+Then("the event handler file contains the description", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, description);
 });
 
-Then("the event handler file contains the default path expression", (p, world) => {
+Then("the event handler file contains the default path expression", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, "/Tag()");
 });
 
-Then("the event handler file contains the provided path expression", (p, world) => {
+Then("the event handler file contains the provided path expression", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, pathExpression);
 });
 
-Then("the event handler file does not contain the original name", (p, world) => {
+Then("the event handler file does not contain the original name", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "TypeScriptEventHandler");
 });
 
-Then("the event handler file does not contain the original description", (p, world) => {
+Then("the event handler file does not contain the original description", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "sample TypeScript event handler");
 });
 
-Then("the event handler file does not contain the original path expression", (p, world) => {
+Then("the event handler file does not contain the original path expression", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "/Tag()");
 });
 
 const featurePath = `.atomist/tests/handlers/event/${handlerName}Test.feature`;
 
-Then("the event handler test feature file should exist", (p, world) => {
+Then("the event handler test feature file should exist", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileExists(featurePath);
 });
 
-Then("the event handler test feature file contains the name", (p, world) => {
+Then("the event handler test feature file contains the name", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(featurePath, handlerName);
 });
 
-Then("the event handler test feature file does not contain the original name", (p, world) => {
-    return !p.fileContains(featurePath, "TypeScriptEventHandler");
-});
+Then("the event handler test feature file does not contain the original name",
+    (p: Project, w: ProjectScenarioWorld) => {
+        return !p.fileContains(featurePath, "TypeScriptEventHandler");
+    },
+);
 
-Then("the event handler file does not contain the original intent", (p, world) => {
+Then("the event handler file does not contain the original intent", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "run TypeScriptEventHandler");
 });
 
 const stepsPath = `.atomist/tests/handlers/event/${handlerName}Steps.ts`;
 
-Then("the event handler test steps file should exist", (p, world) => {
+Then("the event handler test steps file should exist", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileExists(stepsPath);
 });
 
-Then("the event handler test steps file contains the name", (p, world) => {
+Then("the event handler test steps file contains the name", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(stepsPath, handlerName);
 });
 
-Then("the event handler test steps file does not contain the original name", (p, world) => {
+Then("the event handler test steps file does not contain the original name", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(stepsPath, "TypeScriptEventHandler");
 });
 
-Then("the event handler file should import the proper node type", (p, world) => {
+Then("the event handler file should import the proper node type", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, `import { ${newRootNode} } from "@atomist/cortex/${newRootNode}";`);
 });
 
-Then("the event handler file should use the proper type parameters", (p, world) => {
+Then("the event handler file should use the proper type parameters", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, `implements HandleEvent<${newRootNode}, ${newRootNode}>`);
 });
 
-Then("the event handler file should have the proper root node type", (p, world) => {
+Then("the event handler file should have the proper root node type", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, `const root: ${newRootNode} = event.root;`);
 });
 
-Then("the event handler file should not import the original root node", (p, world) => {
+Then("the event handler file should not import the original root node", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "import { Tag }");
 });
 
-Then("the event handler file should not use the original type parameters", (p, world) => {
+Then("the event handler file should not use the original type parameters", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "HandleEvent<Tag, Tag>");
 });
 
-Then("the event handler file should not have the original root node type", (p, world) => {
+Then("the event handler file should not have the original root node type", (p: Project, w: ProjectScenarioWorld) => {
     return !p.fileContains(handlerPath, "const root: Tag = event.root;");
 });
 
-Then("the event handler file should define tags", (p, world) => {
+Then("the event handler file should define tags", (p: Project, w: ProjectScenarioWorld) => {
     return p.fileContains(handlerPath, "@Tags");
 });
 
-Then("the event handler test steps file does not contain the original root node type", (p, world) => {
-    return !p.fileContains(stepsPath, "Tag");
-});
+Then("the event handler test steps file does not contain the original root node type",
+    (p: Project, w: ProjectScenarioWorld) => {
+        return !p.fileContains(stepsPath, "Tag");
+    },
+);
 
-Then("the event handler test feature file does not contain the original root node type", (p, world) => {
-    return !p.fileContains(featurePath, "Tag");
-});
+Then("the event handler test feature file does not contain the original root node type",
+    (p: Project, w: ProjectScenarioWorld) => {
+        return !p.fileContains(featurePath, "Tag");
+    },
+);

--- a/.atomist/tests/project/AddTypeScriptEventHandlerTest.feature
+++ b/.atomist/tests/project/AddTypeScriptEventHandlerTest.feature
@@ -20,7 +20,7 @@ Feature: AddTypeScriptEventHandler should add a sample event handler
 
 
   Scenario: AddTypeScriptEventHandler should add an event handler using default path expression to a Rug project
-    Given a manifest file
+    Given a Rug archive manifest
     Given an NPM package file
     When AddTypeScriptEventHandler is run with default path expression
     Then parameters were valid
@@ -40,7 +40,7 @@ Feature: AddTypeScriptEventHandler should add a sample event handler
 
 
   Scenario: AddTypeScriptEventHandler should add an event handler to a Rug project
-    Given a manifest file
+    Given a Rug archive manifest
     Given an NPM package file
     When AddTypeScriptEventHandler is run providing a path expression
     Then parameters were valid

--- a/.atomist/tests/project/AddTypeScriptSteps.ts
+++ b/.atomist/tests/project/AddTypeScriptSteps.ts
@@ -22,11 +22,14 @@ Given("a Rug archive manifest", (p: Project) => {
 artifact: some-rugs
 version: "28.8.1963"
 requires: "[0.25.3,0.26.0)"
+dependencies:
+- "atomist:rug-rugs:[0.30.0,1.0.0)"
+extensions:
+- "com.atomist.rug:rug-function-http:[0.7.3,1.0.0)"
 `);
 });
 
-When("edit with AddTypeScript", (p, world) => {
-    const w = world as ProjectScenarioWorld;
+When("edit with AddTypeScript", (p: Project, w: ProjectScenarioWorld) => {
     const editor = w.editor("AddTypeScript");
     w.editWith(editor, {});
 });

--- a/.atomist/tests/project/BumpVersionSteps.ts
+++ b/.atomist/tests/project/BumpVersionSteps.ts
@@ -17,7 +17,7 @@
 import { Project } from "@atomist/rug/model/Project";
 import { Given, ProjectScenarioWorld, Then, When } from "@atomist/rug/test/project/Core";
 
-Given("a manifest file with version (.*)", (p: Project, w: ProjectScenarioWorld, version: string) => {
+Given("a Rug archive manifest with version (.*)", (p: Project, w: ProjectScenarioWorld, version: string) => {
     p.addFile(".atomist/manifest.yml", `group: test-rugs
 artifact: test-manifest
 version: ${version}

--- a/.atomist/tests/project/BumpVersionTest.feature
+++ b/.atomist/tests/project/BumpVersionTest.feature
@@ -19,31 +19,31 @@ Feature: Automatically increment Rug archive version
 
 
   Scenario: BumpVersion should increment the major version
-    Given a manifest file
+    Given a Rug archive manifest
     When BumpVersion bumps the major version
     Then parameters were valid
     Then changes were made
-    Then file at .atomist/manifest.yml should contain version: "1.0.0"
+    Then file at .atomist/manifest.yml should contain version: "29.0.0"
 
 
   Scenario: BumpVersion should increment the minor version
-    Given a manifest file
+    Given a Rug archive manifest
     When BumpVersion bumps the minor version
     Then parameters were valid
     Then changes were made
-    Then file at .atomist/manifest.yml should contain version: "0.2.0"
+    Then file at .atomist/manifest.yml should contain version: "28.9.0"
 
 
   Scenario: BumpVersion should increment the patch level
-    Given a manifest file
+    Given a Rug archive manifest
     When BumpVersion bumps the patch version
     Then parameters were valid
     Then changes were made
-    Then file at .atomist/manifest.yml should contain version: "0.1.1"
+    Then file at .atomist/manifest.yml should contain version: "28.8.1964"
 
 
   Scenario: BumpVersion should increment version without quotes
-    Given a manifest file with version 17.6.3
+    Given a Rug archive manifest with version 17.6.3
     When BumpVersion bumps the minor version
     Then parameters were valid
     Then changes were made
@@ -51,7 +51,7 @@ Feature: Automatically increment Rug archive version
 
 
   Scenario: BumpVersion should increment prerelease version
-    Given a manifest file with version 17.6.3-SNAPSHOT
+    Given a Rug archive manifest with version 17.6.3-SNAPSHOT
     When BumpVersion bumps the patch version
     Then parameters were valid
     Then changes were made
@@ -59,7 +59,7 @@ Feature: Automatically increment Rug archive version
 
 
   Scenario: AddManifestYml should refuse to change bad version
-    Given a manifest file with version "1.0"
+    Given a Rug archive manifest with version "1.0"
     When BumpVersion bumps the major version
     Then the scenario aborted
 

--- a/.atomist/tests/project/UpdateRugSteps.ts
+++ b/.atomist/tests/project/UpdateRugSteps.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Project } from "@atomist/rug/model/Project";
+import { Given, ProjectScenarioWorld, Then, When } from "@atomist/rug/test/project/Core";
+
+const manifest = ".atomist/manifest.yml";
+const packageJson = ".atomist/package.json";
+
+When("UpdateRug is run", (p: Project, w: ProjectScenarioWorld) => {
+    const editor = w.editor("UpdateRug");
+    w.editWith(editor, {});
+});
+
+Then("the manifest file requires the current version of rug", (p: Project, w: ProjectScenarioWorld) => {
+    const archiveManifest = "manny.yml";
+    p.copyEditorBackingFileOrFailToDestination(manifest, archiveManifest);
+    const req = p.findFile(archiveManifest).content.split("\n").filter((l) => /^requires:/.test(l));
+    return p.fileContains(manifest, req[0]);
+});
+
+Then("the package file depends on the current version of rugs", (p: Project, w: ProjectScenarioWorld) => {
+    const archivePkg = "pkg.json";
+    p.copyEditorBackingFileOrFailToDestination(packageJson, archivePkg);
+    const dep = p.findFile(archivePkg).content.split("\n").filter((l) => /"@atomist\/rugs":/.test(l));
+    return p.fileContains(packageJson, dep[0]);
+});

--- a/.atomist/tests/project/UpdateRugTest.feature
+++ b/.atomist/tests/project/UpdateRugTest.feature
@@ -1,0 +1,48 @@
+# Copyright © 2017 Atomist, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: Bring a Rug project up to the latest versions and conventions
+  We should be able to update a Rug project files to use
+  the latest version of rug and @atomist/rugs as well as
+  the latest TypeScript and build configuration.
+
+
+  Scenario: UpdateRug should safely update Rug dependencies and support files
+    Given a Rug archive manifest
+    Given an NPM package file
+    When UpdateRug is run
+    Then parameters were valid
+    Then changes were made
+    Then file at .atomist/manifest.yml should exist
+    Then file at .atomist/package.json should exist
+    Then the manifest file requires the current version of rug
+    Then file at .atomist/manifest.yml should contain group: non-atomist
+    Then file at .atomist/manifest.yml should contain artifact: some-rugs
+    Then file at .atomist/manifest.yml should contain version: "28.8.1963"
+    Then the package file depends on the current version of rugs
+    Then file at .atomist/package.json should contain "mustache": "^2.3.0"
+    Then file at .atomist/package.json should contain devDependencies
+    Then file at .atomist/package.json should contain "test": "mocha"
+    Then file at .atomist/package.json should contain "lint": "tslint '**/*.ts' --exclude 'node_modules/**' -t verbose",
+    Then file at .atomist/.gitignore should exist
+    Then file at .atomist/tsconfig.json should exist
+    Then file at .atomist/tslint.json should exist
+    Then file at .atomist/build/travis-build.bash should exist
+    Then file at .atomist/build/cli.yml should exist
+
+
+  Scenario: UpdateRug should abort if project is not a Rug project
+    Given an empty project
+    When UpdateRug is run
+    Then the scenario aborted

--- a/.atomist/tests/project/UpdateSupportFilesSteps.ts
+++ b/.atomist/tests/project/UpdateSupportFilesSteps.ts
@@ -31,19 +31,6 @@ script: bash .atomist/build/travis-build.bash
 `);
 });
 
-Given("an NPM package file", (p: Project) => {
-    p.addFile(".atomist/package.json", `{
-  "dependencies": {
-    "@atomist/rugs": "^0.24.2",
-    "mustache": "^2.3.0"
-  },
-  "devDependencies": {
-    "@types/mustache": "^0.8.29"
-  }
-}
-`);
-});
-
 Given("old build CLI configs", (p: Project) => {
     p.addFile(".atomist/build/cli-build.yml", "chavo: guerrero");
     p.addFile(".atomist/build/cli-dev.yml", "foreign: object");

--- a/.atomist/yarn.lock
+++ b/.atomist/yarn.lock
@@ -354,6 +354,10 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+deprecated-decorator@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
+
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
@@ -1409,7 +1413,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-string-width@^1.0.1:
+string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -1476,8 +1480,8 @@ tar-fs@^1.15.1:
     tar-stream "^1.1.2"
 
 tar-stream@^1.1.2, tar-stream@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.4.tgz#36549cf04ed1aee9b2a30c0143252238daf94016"
   dependencies:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
@@ -1605,10 +1609,10 @@ which@1:
     isexe "^2.0.0"
 
 wide-align@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
-    string-width "^1.0.1"
+    string-width "^1.0.2"
 
 wordwrap@~0.0.2:
   version "0.0.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Command handler `show latest versions` that displays the latest versions
     of `com.atomist:rug` and `@atomist/rugs`
 -   BumpVersion editor
+-   UpdateRug editor
+-   isRugArchive and isSetupForTypeScript functions
+-   NotRugArchiveError class
+
+### Deprecated
+
+-   IsRugArchive and IsSetupForTypeScript functions
 
 [51]: https://github.com/atomist/rug-rugs/issues/51
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,39 @@ This will add the an event handler at
 `.atomist/handlers/event/MyNewEventHandler.ts` and corresponding tests
 to the project.
 
+### BumpVersion
+
+The BumpVersion editor increments one of the elements of
+the [semantic version][semver] your Rug project, setting all trailing
+elements to zero.
+
+#### Prerequisites
+
+Before running this editor, you must have the following prerequisites
+satisfied.
+
+*   A Rug project with a `.atomist/manifest.yml` file having a version
+
+#### Parameters
+
+To run this editor, you must supply the following parameters.
+
+Name | Required | Default | Description
+-----|----------|---------|------------
+`component` | No | minor | Element of the semantic version of the project to increment.
+
+#### Running
+
+Run it as follows:
+
+```
+$ cd project/directory
+$ rug edit atomist:rug-rugs:BumpVersion component=patch
+```
+
+This will increment the last element of the version in
+`.atomist/manifest.yml`.
+
 ### ConvertExistingProjectToGenerator
 
 The ConvertExistingProjectToGenerator editor creates a valid Rug
@@ -443,7 +476,7 @@ $ ( cd .atomist && npm install )
 ## ShowLatestVersions
 
 The ShowLatestVerrsions command handler displays the latest versions of
-`com.atomist:rug` and `@atomist/rugs` in Slack. 
+`com.atomist:rug` and `@atomist/rugs` in Slack.
 
 ### Parameters
 
@@ -475,6 +508,36 @@ and in .atomist/package.json use:
 
 Latest Rug CLI version is 1.0.0-m.1.
 ```
+
+### UpdateRug
+
+The UpdateRug editor updates the Rug dependencies and support files of
+a Rug project to the values in this Rug archive project.
+
+#### Prerequisites
+
+Before running this editor, you must have the following prerequisites
+satisfied.
+
+*   A Rug project with a `.atomist/manifest.yml` file
+
+#### Parameters
+
+This editor has no parameters.
+
+#### Running
+
+Run it as follows:
+
+```
+$ cd project/directory
+$ rug edit atomist:rug-rugs:UpdateRug
+```
+
+This will update the required version in the `.atomist/manifest.yml`
+file and the `@atomist/rugs` dependency in the `.atomist/package.json`
+file.  It will also update all the Rug support files,
+see [UpdateSupportFiles](#updatesupportfiles).
 
 ### UpdateSupportFiles
 


### PR DESCRIPTION
Add UpdateRug editor to update rug dependencies and support files.

Rename predicate functions to start with lower case letter, as is
convention.  Deprecate old versions.

Update rug and @atomist/rugs to latest.

Add NotRugArchiveError class to reduce duplication.

Fix parameter descriptions in AddTypeScriptCommandHandler.

Clean up tests: more types, consolidate steps.

Closes #49