### PR TITLE
use Core to bring in project

### DIFF
--- a/.atomist/editors/TypeScriptEditor.ts
+++ b/.atomist/editors/TypeScriptEditor.ts
@@ -1,4 +1,4 @@
-import { Project } from "@atomist/rug/model/Project";
+import { Project } from "@atomist/rug/model/Core";
 import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 import { Pattern } from "@atomist/rug/operations/RugOperation";


### PR DESCRIPTION
This way, when I want to add File as an import, I can get it from the same place.
Core re-exports all the important ones, which is one tiny bit easier to use than adding a separate import per.