### PR TITLE
Give the sample editor test a before and after file

### DIFF
--- a/.atomist/editors/TypeScriptEditor.ts
+++ b/.atomist/editors/TypeScriptEditor.ts
@@ -1,4 +1,4 @@
-import { Project } from "@atomist/rug/model/Project";
+import { File, Project } from "@atomist/rug/model/Core";
 import { Editor, Parameter, Tags } from "@atomist/rug/operations/Decorators";
 import { EditProject } from "@atomist/rug/operations/ProjectEditor";
 import { Pattern } from "@atomist/rug/operations/RugOperation";
@@ -21,7 +21,9 @@ export class TypeScriptEditor implements EditProject {
     public inputParameter: string;
 
     public edit(project: Project) {
-        project.addFile("hello.txt", "Hello, World!\n" + this.inputParameter + "\n");
+        const certainFile = project.findFile("hello.txt");
+        const newContent = certainFile.content.replace(/the world/, this.inputParameter);
+        certainFile.setContent(newContent);
     }
 }
 

--- a/.atomist/tests/project/TypeScriptEditorSteps.ts
+++ b/.atomist/tests/project/TypeScriptEditorSteps.ts
@@ -3,13 +3,34 @@ import {
     Given, ProjectScenarioWorld, Then, When,
 } from "@atomist/rug/test/project/Core";
 
+const CERTAIN_INPUT_FILEPATH = "hello.txt";
+
+const CERTAIN_FILE_CONTENT_BEFORE = `I love to say hello
+
+to the world
+`;
+
+const CERTAIN_FILE_CONTENT_AFTER = `I love to say hello
+
+to you
+`;
+
+Given("a project with a certain file", (p: Project, world) => {
+    p.addFile(CERTAIN_INPUT_FILEPATH, CERTAIN_FILE_CONTENT_BEFORE);
+});
+
 When("the TypeScriptEditor is run", (p: Project, world) => {
     const w = world as ProjectScenarioWorld;
     const editor = w.editor("TypeScriptEditor");
-    w.editWith(editor, { inputParameter: "the inputParameter value" });
+    w.editWith(editor, { inputParameter: "you" });
 });
 
-Then("the hello file says hello", (p: Project, world) => {
+Then("that certain file looks different", (p: Project, world) => {
     const w = world as ProjectScenarioWorld;
-    return p.fileContains("hello.txt", "Hello, World!");
+    const after = p.findFile(CERTAIN_INPUT_FILEPATH).content;
+    const passing = (after === CERTAIN_FILE_CONTENT_AFTER);
+    if (!passing) {
+        console.log(`FAILURE: ${CERTAIN_INPUT_FILEPATH} --->\n${after}\n<---`);
+    }
+    return passing;
 });

--- a/.atomist/tests/project/TypeScriptEditorTest.feature
+++ b/.atomist/tests/project/TypeScriptEditorTest.feature
@@ -5,8 +5,8 @@ Feature: Make sure the sample TypeScript Editor has some tests
 
 
   Scenario: TypeScriptEditor should edit a project correctly
-    Given an empty project
+    Given a project with a certain file
     When the TypeScriptEditor is run
     Then parameters were valid
     Then changes were made
-    Then the hello file says hello
+    Then that certain file looks different


### PR DESCRIPTION
OK. This comes from my own difficulties writing tests for editors.

When I'm holding in my head the existing code that I want to change, plus what I want to change it to, plus rug, plus typescript, plus gherkin, plus our own framework ... 💥 
my head esplodes.

One piece that can help, is: if I have the before and after of the code I want to change in my head, I could put those in a spot in the test for the editor. I think this more useful than the existing sample test, which tests adding a file.

There may be parts of this PR that you like better -- for example, I always have to add that console.log to a Gherkin test to get any information about what it actually did, since the assertion does not print the things that didn't match, and the output of the editor is gone when the tests exit. Maybe there's a better way to do that but this one works. So I keep doing it. So it seems useful to be in the sample.

We could also consider using a path expression to get at the file, because then the sample would include that, and it's easier to delete the path expression and discover findFile than the other way around. Currently I have the path expression syntax memorized but others don't.

I think the before/after bit of this sample test is important; open to discussion on the rest; also we could merge this and separately discuss the rest.

